### PR TITLE
Add adotop to Community Tools and Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The _Awesome Azure DevOps 🚀_ repository contains a list of Azure DevOps conte
 [Back To Top](#table-of-contents)
 <!-- markdown-link-check-enable -->
 
+- [adotop](https://github.com/superyyrrzz/adotop) - Terminal UI for Azure DevOps pull requests: browse, diff, comment, and approve from the terminal
 - [Azure DevOps Stream Deck plugin by Panu Oksala](https://apps.elgato.com/plugins/net.oksala.azuredevops)
 - [PSRule.Rules.AzureDevOps ADO configuration best practices audit](https://github.com/cloudyspells/PSRule.Rules.AzureDevOps)
 - Azure Devops Migration Tools


### PR DESCRIPTION
Adds [adotop](https://github.com/superyyrrzz/adotop) to the Community Tools and Extensions section. It's a terminal UI for Azure DevOps PR review — browse PRs across tabs, read diffs with syntax highlighting, walk threads inline under their target diff line, leave comments via an in-TUI textarea, approve / vote / abandon, view per-commit diffs, and detect stale approvals.

Built on Bubble Tea. Installs via Scoop, Homebrew, or `go install`.

Sorted alphabetically (lands above the Stream Deck plugin entry).