### PR TITLE
Add DevIntern

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ The _Awesome Azure DevOps 🚀_ repository contains a list of Azure DevOps conte
 - [adotop](https://github.com/superyyrrzz/adotop) - Terminal UI for Azure DevOps pull requests: browse, diff, comment, and approve from the terminal
 - [Azent](https://azent.tech) - Background AI coding agent for Azure DevOps. Trigger Claude or Codex via @mention.
 - [Azure DevOps Stream Deck plugin by Panu Oksala](https://apps.elgato.com/plugins/net.oksala.azuredevops)
+- [DevIntern](https://devintern.com) - Tool that turns Azure DevOps work items into self-reviewed pull requests using Claude Code, Codex, Cursor, or OpenCode on your own machines.
 - [PSRule.Rules.AzureDevOps ADO configuration best practices audit](https://github.com/cloudyspells/PSRule.Rules.AzureDevOps)
 - Azure Devops Migration Tools
   - [Azure Devops Migration Tools Homepage](https://devopsmigration.io/)


### PR DESCRIPTION
Adds [DevIntern](https://devintern.com) to Community Tools and Extensions, in alphabetical order.

DevIntern is a tool that picks up Azure DevOps work items and turns them into self-reviewed pull requests using the coding agent of your choice (Claude Code, Codex, Cursor, or OpenCode), running on your own machines with your own model keys. A feasibility gate flags vague work items back to the board with questions before any code is written.

Repo: https://github.com/getdevintern/devintern
Docs: https://devintern.com/docs

Free for interactive use (FSL-1.1 source-available license).